### PR TITLE
Add helper functions for GOST support

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -190,8 +190,13 @@ gpg_error_t uncompress_ecc_q_in_canon_sexp (const unsigned char *keydata,
                                             size_t *r_newkeydatalen);
 
 int get_pk_algo_from_key (gcry_sexp_t key);
+int get_pk_info_from_key (gcry_sexp_t key, char **r_oid, char **r_curve_oid,
+                          char **r_digest_oid);
 int get_pk_algo_from_canon_sexp (const unsigned char *keydata,
                                  size_t keydatalen);
+int get_pk_info_from_canon_sexp (const unsigned char *keydata,
+                                 size_t keydatalen, char **r_oid,
+                                 char **r_curve_oid, char **r_digest_oid);
 char *pubkey_algo_string (gcry_sexp_t s_pkey, enum gcry_pk_algos *r_algoid);
 const char *pubkey_algo_to_string (int algo);
 const char *hash_algo_to_string (int algo);


### PR DESCRIPTION
## Summary
- add `get_pk_info_from_key` and `get_pk_info_from_canon_sexp` to parse
  additional information from public keys
- expose new helper prototypes in `util.h`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8db4cf3c832eb54db37ade032d65