### PR TITLE
Add GOST helper sources

### DIFF
--- a/g10/Makefile.am
+++ b/g10/Makefile.am
@@ -117,7 +117,13 @@ common_source =  \
               pkglue.c pkglue.h \
               objcache.c objcache.h \
               ecdh.c \
-              gost.c
+              $(g10_common_sources)
+
+g10_common_sources = \
+  gost.c \
+  gost-kdf.c \
+  gost-map.c \
+  gost-helper.c
 
 gpg_sources = server.c          \
 	      $(common_source)	\

--- a/g10/gost-helper.c
+++ b/g10/gost-helper.c
@@ -1,0 +1,85 @@
+#include <config.h>
+#include <string.h>
+
+#include "gost-helper.h"
+#include "../common/util.h"
+
+static gpg_error_t
+unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
+{
+  gpg_error_t ret = 0;
+  gost_kdf_params_t *p;
+  unsigned int pos = 0;
+
+  p = xtrycalloc (1, sizeof *p);
+  if (!p)
+    return gpg_error_from_syserror ();
+
+  p->vko_algo = packed[pos++];
+  switch (p->vko_algo)
+    {
+    case VKO_7836:
+      p->vko_params.vko_7836.ukm_len = packed[pos++];
+      p->vko_params.vko_7836.vko_digest_algo = packed[pos++];
+      p->vko_params.vko_7836.vko_digest_params = packed[pos++];
+      break;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      goto fail;
+    }
+
+  p->kdf_algo = packed[pos++];
+  switch (p->kdf_algo)
+    {
+    case GOST_KDF_CPDIVERS:
+      p->kdf_params.kdf_4357.kdf_cipher_algo = packed[pos++];
+      p->kdf_params.kdf_4357.kdf_cipher_params = packed[pos++];
+      break;
+    case KDF_NULL:
+      break;
+    case GOST_KDF_TREE:
+      ret = GPG_ERR_UNSUPPORTED_ALGORITHM;
+      goto fail;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      goto fail;
+    }
+
+  p->keywrap_algo = packed[pos++];
+  switch (p->keywrap_algo)
+    {
+    case KEYWRAP_7836:
+      p->keywrap_params.keywrap_7836.keywrap_mac_algo = packed[pos++];
+      p->keywrap_params.keywrap_7836.keywrap_mac_params = packed[pos++];
+      p->keywrap_params.keywrap_7836.keywrap_cipher_algo = packed[pos++];
+      p->keywrap_params.keywrap_7836.keywrap_cipher_params = packed[pos++];
+      break;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      goto fail;
+    }
+
+  *r_params = p;
+  return 0;
+
+ fail:
+  xfree (p);
+  return ret;
+}
+
+/* Extract VKO/KDF parameters from a public key MPI array.  */
+gpg_error_t
+pk_gost_get_kdf_params (gcry_mpi_t *pkey, gost_kdf_params_t **r_params)
+{
+  const unsigned char *p;
+  size_t size;
+  unsigned int nbits;
+
+  p = gcry_mpi_get_opaque (pkey[2], &nbits);
+  size = (nbits + 7)/8;
+  if (size > 2 && p[1] != GOST_KDF_PARAMS_VERSION)
+    return GPG_ERR_BAD_PUBKEY;
+
+  return unpack_gost_kdf_params ((unsigned char*)p + 2, r_params);
+}
+

--- a/g10/gost-helper.h
+++ b/g10/gost-helper.h
@@ -1,0 +1,11 @@
+#ifndef GNUPG_G10_GOST_HELPER_H
+#define GNUPG_G10_GOST_HELPER_H
+
+#include "gost-kdf.h"
+#include <gcrypt.h>
+#include <gpg-error.h>
+
+gpg_error_t pk_gost_get_kdf_params (gcry_mpi_t *pkey,
+                                    gost_kdf_params_t **r_params);
+
+#endif /* GNUPG_G10_GOST_HELPER_H */

--- a/g10/gost-kdf.c
+++ b/g10/gost-kdf.c
@@ -1,0 +1,162 @@
+#include <config.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "gost-kdf.h"
+#include "gost-map.h"
+#include "../common/gost-util.h"
+#include "../common/util.h"
+#include "main.h" /* for map_md_openpgp_to_gcry */
+
+static const char *
+digest_params_to_oid (digest_params_t params)
+{
+  switch (params)
+    {
+    case DIGEST_PARAMS_GOSTR3411_94_A:
+      return "1.2.643.2.2.30.1";
+    default:
+      return NULL;
+    }
+}
+
+static gpg_error_t
+unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
+{
+  gpg_error_t ret = 0;
+  gost_kdf_params_t *p;
+  unsigned int pos = 0;
+
+  p = xtrycalloc (1, sizeof *p);
+  if (!p)
+    return gpg_error_from_syserror ();
+
+  p->vko_algo = packed[pos++];
+  switch (p->vko_algo)
+    {
+    case VKO_7836:
+      p->vko_params.vko_7836.ukm_len = packed[pos++];
+      p->vko_params.vko_7836.vko_digest_algo = packed[pos++];
+      p->vko_params.vko_7836.vko_digest_params = packed[pos++];
+      break;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      goto fail;
+    }
+
+  p->kdf_algo = packed[pos++];
+  switch (p->kdf_algo)
+    {
+    case GOST_KDF_CPDIVERS:
+      p->kdf_params.kdf_4357.kdf_cipher_algo = packed[pos++];
+      p->kdf_params.kdf_4357.kdf_cipher_params = packed[pos++];
+      break;
+    case KDF_NULL:
+      break;
+    case GOST_KDF_TREE:
+      /* not implemented */
+      ret = GPG_ERR_UNSUPPORTED_ALGORITHM;
+      goto fail;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      goto fail;
+    }
+
+  p->keywrap_algo = packed[pos++];
+  switch (p->keywrap_algo)
+    {
+    case KEYWRAP_7836:
+      p->keywrap_params.keywrap_7836.keywrap_mac_algo = packed[pos++];
+      p->keywrap_params.keywrap_7836.keywrap_mac_params = packed[pos++];
+      p->keywrap_params.keywrap_7836.keywrap_cipher_algo = packed[pos++];
+      p->keywrap_params.keywrap_7836.keywrap_cipher_params = packed[pos++];
+      break;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      goto fail;
+    }
+
+  *r_params = p;
+  return 0;
+
+ fail:
+  xfree (p);
+  return ret;
+}
+
+void
+free_gost_kdf_params (gost_kdf_params_t *p)
+{
+  if (!p)
+    return;
+  if (p->kdf_algo == GOST_KDF_TREE && p->kdf_params.kdf_7836.label)
+    xfree (p->kdf_params.kdf_7836.label);
+  xfree (p);
+}
+
+static gpg_error_t
+kdf_tree_notimpl (void)
+{
+  return GPG_ERR_UNSUPPORTED_ALGORITHM;
+}
+
+gpg_error_t
+gost_kdf (const gost_kdf_params_t *params, gcry_mpi_t ukm,
+          const unsigned char *shared_buf, size_t shared_len,
+          gcry_mpi_t *out_kek)
+{
+  gpg_error_t ret = 0;
+
+  switch (params->kdf_algo)
+    {
+    case KDF_NULL:
+      *out_kek = gcry_mpi_set_opaque_copy (*out_kek, shared_buf,
+                                           8 * shared_len);
+      break;
+    case GOST_KDF_CPDIVERS:
+      ret = gost_cpdiversify_key (out_kek,
+                                  map_cipher_openpgp_to_gcry (params->kdf_params.kdf_4357.kdf_cipher_algo),
+                                  cipher_params_to_sbox (params->kdf_params.kdf_4357.kdf_cipher_params),
+                                  shared_buf, shared_len, ukm);
+      break;
+    case GOST_KDF_TREE:
+      ret = kdf_tree_notimpl ();
+      break;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      break;
+    }
+  return ret;
+}
+
+gpg_error_t
+gost_vko_kdf (const gost_kdf_params_t *params, gcry_mpi_t shared,
+              gcry_mpi_t ukm, gcry_mpi_t *out_kek)
+{
+  gpg_error_t ret = 0;
+  unsigned char *buf = NULL;
+  size_t buflen = 0;
+
+  switch (params->vko_algo)
+    {
+    case VKO_7836:
+      ret = gost_vko (shared,
+                      map_md_openpgp_to_gcry (params->vko_params.vko_7836.vko_digest_algo),
+                      digest_params_to_oid (params->vko_params.vko_7836.vko_digest_params),
+                      &buf, &buflen);
+      break;
+    default:
+      ret = GPG_ERR_UNKNOWN_ALGORITHM;
+      break;
+    }
+  if (ret)
+    {
+      xfree (buf);
+      return ret;
+    }
+
+  ret = gost_kdf (params, ukm, buf, buflen, out_kek);
+  xfree (buf);
+  return ret;
+}
+

--- a/g10/gost-kdf.h
+++ b/g10/gost-kdf.h
@@ -1,0 +1,95 @@
+#ifndef GNUPG_G10_GOST_KDF_H
+#define GNUPG_G10_GOST_KDF_H
+
+#include "../common/openpgpdefs.h"
+#include <gcrypt.h>
+#include <gpg-error.h>
+
+#define GOST_KDF_PARAMS_VERSION 2
+
+/* Parameter descriptors.  */
+typedef enum
+  {
+    DIGEST_PARAMS_UNSPECIFIED = 0,
+    DIGEST_PARAMS_GOSTR3411_94_A = 1
+  } digest_params_t;
+
+typedef enum
+  {
+    CIPHER_PARAMS_GOST28147_A = 1,
+    CIPHER_PARAMS_GOST28147_B = 2,
+    CIPHER_PARAMS_GOST28147_C = 3,
+    CIPHER_PARAMS_GOST28147_D = 4,
+    CIPHER_PARAMS_GOST28147_Z = 5
+  } cipher_params_t;
+
+typedef enum
+  {
+    MAC_PARAMS_UNSPECIFIED = 0,
+    MAC_PARAMS_GOST28147_A = 1,
+    MAC_PARAMS_GOST28147_B = 2,
+    MAC_PARAMS_GOST28147_C = 3,
+    MAC_PARAMS_GOST28147_D = 4,
+    MAC_PARAMS_GOST28147_Z = 5
+  } mac_params_t;
+
+typedef enum { VKO_7836 = 1 } vko_algo_t;
+
+typedef enum { KDF_NULL = 0, GOST_KDF_CPDIVERS = 1, GOST_KDF_TREE = 2 } kdf_algo_t;
+
+typedef enum { KEYWRAP_7836 = 1 } keywrap_algo_t;
+
+typedef struct
+{
+  vko_algo_t vko_algo;
+  union
+  {
+    struct
+    {
+      unsigned char ukm_len;
+      digest_algo_t   vko_digest_algo;
+      digest_params_t vko_digest_params;
+    } vko_7836;
+  } vko_params;
+  kdf_algo_t kdf_algo;
+  union
+  {
+    struct
+    {
+      cipher_algo_t kdf_cipher_algo;
+      cipher_params_t kdf_cipher_params;
+    } kdf_4357;
+    struct
+    {
+      unsigned char seed_len;
+      char *label;
+      unsigned char R;
+      unsigned int L;
+      digest_algo_t   kdf_digest_algo;
+      digest_params_t kdf_digest_params;
+    } kdf_7836;
+  } kdf_params;
+  keywrap_algo_t keywrap_algo;
+  union
+  {
+    struct
+    {
+      mac_algo_t   keywrap_mac_algo;
+      mac_params_t keywrap_mac_params;
+      cipher_algo_t   keywrap_cipher_algo;
+      cipher_params_t keywrap_cipher_params;
+    } keywrap_7836;
+  } keywrap_params;
+} gost_kdf_params_t;
+
+/* Function prototypes.  */
+gpg_error_t gost_vko_kdf (const gost_kdf_params_t *params, gcry_mpi_t shared,
+                          gcry_mpi_t ukm, gcry_mpi_t *out_kek);
+
+gpg_error_t gost_kdf (const gost_kdf_params_t *params, gcry_mpi_t ukm,
+                       const unsigned char *shared_buf, size_t shared_len,
+                       gcry_mpi_t *out_kek);
+
+void free_gost_kdf_params (gost_kdf_params_t *params);
+
+#endif /* GNUPG_G10_GOST_KDF_H */

--- a/g10/gost-map.c
+++ b/g10/gost-map.c
@@ -1,0 +1,63 @@
+#include <config.h>
+#include "gost-map.h"
+
+int
+map_cipher_openpgp_to_gcry (int openpgp_id)
+{
+  switch (openpgp_id)
+    {
+    case CIPHER_ALGO_GOST28147:
+#ifdef GCRY_CIPHER_GOST28147
+      return GCRY_CIPHER_GOST28147;
+#else
+      return 0;
+#endif
+    default:
+      return 0;
+    }
+}
+
+const char *
+cipher_params_to_sbox (void *cipher_params)
+{
+  switch ((int)(intptr_t)cipher_params)
+    {
+    case CIPHER_PARAMS_GOST28147_A: return "1.2.643.2.2.31.1";
+    case CIPHER_PARAMS_GOST28147_B: return "1.2.643.2.2.31.2";
+    case CIPHER_PARAMS_GOST28147_C: return "1.2.643.2.2.31.3";
+    case CIPHER_PARAMS_GOST28147_D: return "1.2.643.2.2.31.4";
+    case CIPHER_PARAMS_GOST28147_Z: return "1.2.643.7.1.2.5.1.1";
+    default: return NULL;
+    }
+}
+
+int
+map_mac_openpgp_to_gcry (int openpgp_id)
+{
+  switch (openpgp_id)
+    {
+    case MAC_ALGO_GOST28147_IMIT:
+#ifdef GCRY_MAC_GOST28147_IMIT
+      return GCRY_MAC_GOST28147_IMIT;
+#else
+      return 0;
+#endif
+    default:
+      return 0;
+    }
+}
+
+const char *
+mac_params_to_sbox (void *mac_params)
+{
+  switch ((int)(intptr_t)mac_params)
+    {
+    case MAC_PARAMS_GOST28147_A: return "1.2.643.2.2.31.1";
+    case MAC_PARAMS_GOST28147_B: return "1.2.643.2.2.31.2";
+    case MAC_PARAMS_GOST28147_C: return "1.2.643.2.2.31.3";
+    case MAC_PARAMS_GOST28147_D: return "1.2.643.2.2.31.4";
+    case MAC_PARAMS_GOST28147_Z: return "1.2.643.7.1.2.5.1.1";
+    default: return NULL;
+    }
+}
+

--- a/g10/gost-map.h
+++ b/g10/gost-map.h
@@ -1,0 +1,13 @@
+#ifndef GNUPG_G10_GOST_MAP_H
+#define GNUPG_G10_GOST_MAP_H
+
+#include "gost-kdf.h"
+#include "../common/openpgpdefs.h"
+#include <gcrypt.h>
+
+int map_cipher_openpgp_to_gcry (int openpgp_id);
+const char *cipher_params_to_sbox (void *cipher_params);
+int map_mac_openpgp_to_gcry (int openpgp_id);
+const char *mac_params_to_sbox (void *mac_params);
+
+#endif /* GNUPG_G10_GOST_MAP_H */

--- a/g10/gost.c
+++ b/g10/gost.c
@@ -15,66 +15,18 @@
 #include "../common/gost-util.h"
 #include "pkglue.h"
 #include "main.h"
+#include "gost-kdf.h"
+#include "gost-map.h"
+#include "gost-helper.h"
+
+#ifndef DBG_CRYPTO
+# define DBG_CRYPTO 0
+#endif
 
 /* Version marker used with packed GOST parameter sets.  */
 #define GOST_KDF_PARAMS_VERSION 2
 
-/* -- Parameter descriptors --  */
-typedef enum
-  {
-    DIGEST_PARAMS_UNSPECIFIED = 0,
-    DIGEST_PARAMS_GOSTR3411_94_A = 1
-  } digest_params_t;
-
-typedef enum
-  {
-    CIPHER_PARAMS_GOST28147_A = 1,
-    CIPHER_PARAMS_GOST28147_B = 2,
-    CIPHER_PARAMS_GOST28147_C = 3,
-    CIPHER_PARAMS_GOST28147_D = 4,
-    CIPHER_PARAMS_GOST28147_Z = 5
-  } cipher_params_t;
-
-typedef enum
-  {
-    MAC_PARAMS_UNSPECIFIED = 0,
-    MAC_PARAMS_GOST28147_A = 1,
-    MAC_PARAMS_GOST28147_B = 2,
-    MAC_PARAMS_GOST28147_C = 3,
-    MAC_PARAMS_GOST28147_D = 4,
-    MAC_PARAMS_GOST28147_Z = 5
-  } mac_params_t;
-
-typedef enum { VKO_7836 = 1 } vko_algo_t;
-
-typedef enum { KDF_NULL = 0, GOST_KDF_CPDIVERS = 1 } kdf_algo_t;
-
-typedef enum { KEYWRAP_7836 = 1 } keywrap_algo_t;
-
-typedef struct
-{
-  vko_algo_t vko_algo;
-  struct
-  {
-    unsigned char ukm_len;
-    digest_algo_t vko_digest_algo;
-    digest_params_t vko_digest_params;
-  } vko_7836;
-  kdf_algo_t kdf_algo;
-  struct
-  {
-    cipher_algo_t kdf_cipher_algo;
-    cipher_params_t kdf_cipher_params;
-  } kdf_4357;
-  keywrap_algo_t keywrap_algo;
-  struct
-  {
-    mac_algo_t keywrap_mac_algo;
-    mac_params_t keywrap_mac_params;
-    cipher_algo_t keywrap_cipher_algo;
-    cipher_params_t keywrap_cipher_params;
-  } keywrap_7836;
-} gost_kdf_params_t;
+/* Parameter descriptors moved to gost-kdf.h */
 
 /* Default parameter table for supported curves.  */
 static const struct
@@ -326,7 +278,7 @@ pk_gost_decrypt_with_shared_point (gcry_mpi_t shared, gcry_mpi_t ukm,
 
   if (DBG_CRYPTO)
     {
-      log_printhex ("GOST wrapped value:", data_buf + 1, data_len - 1);
+      log_printhex (data_buf + 1, data_len - 1, "GOST wrapped value:");
       log_printmpi ("GOST UKM:", ukm);
     }
 


### PR DESCRIPTION
## Summary
- introduce GOST key derivation helper implementation
- add helper headers and mapping utilities
- include new sources in `g10` build and update `gost.c`

## Testing
- `make gost.o` (fails: `config.h` missing)

------
https://chatgpt.com/codex/tasks/task_e_684c98e3f61c832ea3982a4aff4fb8af