### PR TITLE
Fix GOST structs and mapping helpers

### DIFF
--- a/g10/gost-helper.c
+++ b/g10/gost-helper.c
@@ -19,9 +19,9 @@ unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
   switch (p->vko_algo)
     {
     case VKO_7836:
-      p->vko_params.vko_7836.ukm_len = packed[pos++];
-      p->vko_params.vko_7836.vko_digest_algo = packed[pos++];
-      p->vko_params.vko_7836.vko_digest_params = packed[pos++];
+      p->vko_7836.ukm_len = packed[pos++];
+      p->vko_7836.vko_digest_algo = packed[pos++];
+      p->vko_7836.vko_digest_params = packed[pos++];
       break;
     default:
       ret = GPG_ERR_UNKNOWN_ALGORITHM;
@@ -32,8 +32,8 @@ unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
   switch (p->kdf_algo)
     {
     case GOST_KDF_CPDIVERS:
-      p->kdf_params.kdf_4357.kdf_cipher_algo = packed[pos++];
-      p->kdf_params.kdf_4357.kdf_cipher_params = packed[pos++];
+      p->kdf_4357.kdf_cipher_algo = packed[pos++];
+      p->kdf_4357.kdf_cipher_params = packed[pos++];
       break;
     case KDF_NULL:
       break;
@@ -49,10 +49,10 @@ unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
   switch (p->keywrap_algo)
     {
     case KEYWRAP_7836:
-      p->keywrap_params.keywrap_7836.keywrap_mac_algo = packed[pos++];
-      p->keywrap_params.keywrap_7836.keywrap_mac_params = packed[pos++];
-      p->keywrap_params.keywrap_7836.keywrap_cipher_algo = packed[pos++];
-      p->keywrap_params.keywrap_7836.keywrap_cipher_params = packed[pos++];
+      p->keywrap_7836.keywrap_mac_algo = packed[pos++];
+      p->keywrap_7836.keywrap_mac_params = packed[pos++];
+      p->keywrap_7836.keywrap_cipher_algo = packed[pos++];
+      p->keywrap_7836.keywrap_cipher_params = packed[pos++];
       break;
     default:
       ret = GPG_ERR_UNKNOWN_ALGORITHM;

--- a/g10/gost-kdf.c
+++ b/g10/gost-kdf.c
@@ -35,9 +35,9 @@ unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
   switch (p->vko_algo)
     {
     case VKO_7836:
-      p->vko_params.vko_7836.ukm_len = packed[pos++];
-      p->vko_params.vko_7836.vko_digest_algo = packed[pos++];
-      p->vko_params.vko_7836.vko_digest_params = packed[pos++];
+      p->vko_7836.ukm_len = packed[pos++];
+      p->vko_7836.vko_digest_algo = packed[pos++];
+      p->vko_7836.vko_digest_params = packed[pos++];
       break;
     default:
       ret = GPG_ERR_UNKNOWN_ALGORITHM;
@@ -48,8 +48,8 @@ unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
   switch (p->kdf_algo)
     {
     case GOST_KDF_CPDIVERS:
-      p->kdf_params.kdf_4357.kdf_cipher_algo = packed[pos++];
-      p->kdf_params.kdf_4357.kdf_cipher_params = packed[pos++];
+      p->kdf_4357.kdf_cipher_algo = packed[pos++];
+      p->kdf_4357.kdf_cipher_params = packed[pos++];
       break;
     case KDF_NULL:
       break;
@@ -66,10 +66,10 @@ unpack_gost_kdf_params (unsigned char *packed, gost_kdf_params_t **r_params)
   switch (p->keywrap_algo)
     {
     case KEYWRAP_7836:
-      p->keywrap_params.keywrap_7836.keywrap_mac_algo = packed[pos++];
-      p->keywrap_params.keywrap_7836.keywrap_mac_params = packed[pos++];
-      p->keywrap_params.keywrap_7836.keywrap_cipher_algo = packed[pos++];
-      p->keywrap_params.keywrap_7836.keywrap_cipher_params = packed[pos++];
+      p->keywrap_7836.keywrap_mac_algo = packed[pos++];
+      p->keywrap_7836.keywrap_mac_params = packed[pos++];
+      p->keywrap_7836.keywrap_cipher_algo = packed[pos++];
+      p->keywrap_7836.keywrap_cipher_params = packed[pos++];
       break;
     default:
       ret = GPG_ERR_UNKNOWN_ALGORITHM;
@@ -89,8 +89,6 @@ free_gost_kdf_params (gost_kdf_params_t *p)
 {
   if (!p)
     return;
-  if (p->kdf_algo == GOST_KDF_TREE && p->kdf_params.kdf_7836.label)
-    xfree (p->kdf_params.kdf_7836.label);
   xfree (p);
 }
 
@@ -115,8 +113,8 @@ gost_kdf (const gost_kdf_params_t *params, gcry_mpi_t ukm,
       break;
     case GOST_KDF_CPDIVERS:
       ret = gost_cpdiversify_key (out_kek,
-                                  map_cipher_openpgp_to_gcry (params->kdf_params.kdf_4357.kdf_cipher_algo),
-                                  cipher_params_to_sbox (params->kdf_params.kdf_4357.kdf_cipher_params),
+                                  map_gost_cipher_openpgp_to_gcry (params->kdf_4357.kdf_cipher_algo),
+                                  cipher_params_to_sbox (&params->kdf_4357.kdf_cipher_params),
                                   shared_buf, shared_len, ukm);
       break;
     case GOST_KDF_TREE:
@@ -141,8 +139,8 @@ gost_vko_kdf (const gost_kdf_params_t *params, gcry_mpi_t shared,
     {
     case VKO_7836:
       ret = gost_vko (shared,
-                      map_md_openpgp_to_gcry (params->vko_params.vko_7836.vko_digest_algo),
-                      digest_params_to_oid (params->vko_params.vko_7836.vko_digest_params),
+                      map_md_openpgp_to_gcry (params->vko_7836.vko_digest_algo),
+                      digest_params_to_oid (params->vko_7836.vko_digest_params),
                       &buf, &buflen);
       break;
     default:

--- a/g10/gost-kdf.h
+++ b/g10/gost-kdf.h
@@ -42,44 +42,28 @@ typedef enum { KEYWRAP_7836 = 1 } keywrap_algo_t;
 typedef struct
 {
   vko_algo_t vko_algo;
-  union
+  struct
   {
-    struct
-    {
-      unsigned char ukm_len;
-      digest_algo_t   vko_digest_algo;
-      digest_params_t vko_digest_params;
-    } vko_7836;
-  } vko_params;
+    unsigned char ukm_len;
+    digest_algo_t   vko_digest_algo;
+    digest_params_t vko_digest_params;
+  } vko_7836;
+
   kdf_algo_t kdf_algo;
-  union
+  struct
   {
-    struct
-    {
-      cipher_algo_t kdf_cipher_algo;
-      cipher_params_t kdf_cipher_params;
-    } kdf_4357;
-    struct
-    {
-      unsigned char seed_len;
-      char *label;
-      unsigned char R;
-      unsigned int L;
-      digest_algo_t   kdf_digest_algo;
-      digest_params_t kdf_digest_params;
-    } kdf_7836;
-  } kdf_params;
+    cipher_algo_t kdf_cipher_algo;
+    cipher_params_t kdf_cipher_params;
+  } kdf_4357;
+
   keywrap_algo_t keywrap_algo;
-  union
+  struct
   {
-    struct
-    {
-      mac_algo_t   keywrap_mac_algo;
-      mac_params_t keywrap_mac_params;
-      cipher_algo_t   keywrap_cipher_algo;
-      cipher_params_t keywrap_cipher_params;
-    } keywrap_7836;
-  } keywrap_params;
+    mac_algo_t   keywrap_mac_algo;
+    mac_params_t keywrap_mac_params;
+    cipher_algo_t   keywrap_cipher_algo;
+    cipher_params_t keywrap_cipher_params;
+  } keywrap_7836;
 } gost_kdf_params_t;
 
 /* Function prototypes.  */

--- a/g10/gost-map.c
+++ b/g10/gost-map.c
@@ -2,7 +2,7 @@
 #include "gost-map.h"
 
 int
-map_cipher_openpgp_to_gcry (int openpgp_id)
+map_gost_cipher_openpgp_to_gcry (int openpgp_id)
 {
   switch (openpgp_id)
     {
@@ -18,9 +18,9 @@ map_cipher_openpgp_to_gcry (int openpgp_id)
 }
 
 const char *
-cipher_params_to_sbox (void *cipher_params)
+cipher_params_to_sbox (cipher_params_t *cipher_params)
 {
-  switch ((int)(intptr_t)cipher_params)
+  switch ((int)(intptr_t)*cipher_params)
     {
     case CIPHER_PARAMS_GOST28147_A: return "1.2.643.2.2.31.1";
     case CIPHER_PARAMS_GOST28147_B: return "1.2.643.2.2.31.2";
@@ -48,9 +48,9 @@ map_mac_openpgp_to_gcry (int openpgp_id)
 }
 
 const char *
-mac_params_to_sbox (void *mac_params)
+mac_params_to_sbox (mac_params_t *mac_params)
 {
-  switch ((int)(intptr_t)mac_params)
+  switch ((int)(intptr_t)*mac_params)
     {
     case MAC_PARAMS_GOST28147_A: return "1.2.643.2.2.31.1";
     case MAC_PARAMS_GOST28147_B: return "1.2.643.2.2.31.2";

--- a/g10/gost-map.h
+++ b/g10/gost-map.h
@@ -5,9 +5,9 @@
 #include "../common/openpgpdefs.h"
 #include <gcrypt.h>
 
-int map_cipher_openpgp_to_gcry (int openpgp_id);
-const char *cipher_params_to_sbox (void *cipher_params);
+int map_gost_cipher_openpgp_to_gcry (int openpgp_id);
+const char *cipher_params_to_sbox (cipher_params_t *params);
 int map_mac_openpgp_to_gcry (int openpgp_id);
-const char *mac_params_to_sbox (void *mac_params);
+const char *mac_params_to_sbox (mac_params_t *params);
 
 #endif /* GNUPG_G10_GOST_MAP_H */

--- a/g10/gost.c
+++ b/g10/gost.c
@@ -34,23 +34,29 @@ static const struct
   const char *oidpfx;
   unsigned int qbits;
   gost_kdf_params_t params;
-} gost_kdf_params_table[] =
-  {
-    { "1.2.643.7.1.2.1.1.", 256,
-      { VKO_7836, { 8, DIGEST_ALGO_GOSTR3411_12_256, DIGEST_PARAMS_UNSPECIFIED },
-        GOST_KDF_CPDIVERS, { CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z },
-        KEYWRAP_7836,
-        { MAC_ALGO_GOST28147_IMIT, MAC_PARAMS_GOST28147_Z,
-          CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z } }
-    },
-    { "1.2.643.7.1.2.1.2.", 512,
-      { VKO_7836, { 8, DIGEST_ALGO_GOSTR3411_12_256, DIGEST_PARAMS_UNSPECIFIED },
-        GOST_KDF_CPDIVERS, { CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z },
-        KEYWRAP_7836,
-        { MAC_ALGO_GOST28147_IMIT, MAC_PARAMS_GOST28147_Z,
-          CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z } }
+} gost_kdf_params_table[] = {{
+    "1.2.643.7.1.2.1.1.", 256,
+    {
+      .vko_algo = VKO_7836,
+      .vko_7836 = { 8, DIGEST_ALGO_GOSTR3411_12_256, DIGEST_PARAMS_UNSPECIFIED },
+      .kdf_algo = GOST_KDF_CPDIVERS,
+      .kdf_4357 = { CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z },
+      .keywrap_algo = KEYWRAP_7836,
+      .keywrap_7836 = { MAC_ALGO_GOST28147_IMIT, MAC_PARAMS_GOST28147_Z,
+                        CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z }
     }
-  };
+  },{
+    "1.2.643.7.1.2.1.2.", 512,
+    {
+      .vko_algo = VKO_7836,
+      .vko_7836 = { 8, DIGEST_ALGO_GOSTR3411_12_256, DIGEST_PARAMS_UNSPECIFIED },
+      .kdf_algo = GOST_KDF_CPDIVERS,
+      .kdf_4357 = { CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z },
+      .keywrap_algo = KEYWRAP_7836,
+      .keywrap_7836 = { MAC_ALGO_GOST28147_IMIT, MAC_PARAMS_GOST28147_Z,
+                        CIPHER_ALGO_GOST28147, CIPHER_PARAMS_GOST28147_Z }
+    }
+  }};
 
 /* Pack parameter set PARAMS into BUF and update LENGTH.  */
 static gpg_error_t
@@ -195,10 +201,10 @@ pk_gost_encrypt_with_shared_point (gcry_mpi_t shared, gcry_mpi_t ukm,
     {
     case KEYWRAP_7836:
       ret = gost_keywrap (&encoded_key,
-                          map_cipher_openpgp_to_gcry (kdf_params->keywrap_params.keywrap_7836.keywrap_cipher_algo),
-                          cipher_params_to_sbox (kdf_params->keywrap_params.keywrap_7836.keywrap_cipher_params),
-                          map_mac_openpgp_to_gcry (kdf_params->keywrap_params.keywrap_7836.keywrap_mac_algo),
-                          mac_params_to_sbox (kdf_params->keywrap_params.keywrap_7836.keywrap_mac_params),
+                          map_gost_cipher_openpgp_to_gcry (kdf_params->keywrap_7836.keywrap_cipher_algo),
+                          cipher_params_to_sbox (&kdf_params->keywrap_7836.keywrap_cipher_params),
+                          map_mac_openpgp_to_gcry (kdf_params->keywrap_7836.keywrap_mac_algo),
+                          mac_params_to_sbox (&kdf_params->keywrap_7836.keywrap_mac_params),
                           data, ukm, kek);
       break;
     default:
@@ -334,10 +340,10 @@ pk_gost_decrypt_with_shared_point (gcry_mpi_t shared, gcry_mpi_t ukm,
     {
     case KEYWRAP_7836:
       ret = gost_keyunwrap (r_result,
-                            map_cipher_openpgp_to_gcry (kdf_params->keywrap_params.keywrap_7836.keywrap_cipher_algo),
-                            cipher_params_to_sbox (kdf_params->keywrap_params.keywrap_7836.keywrap_cipher_params),
-                            map_mac_openpgp_to_gcry (kdf_params->keywrap_params.keywrap_7836.keywrap_mac_algo),
-                            mac_params_to_sbox (kdf_params->keywrap_params.keywrap_7836.keywrap_mac_params),
+                            map_gost_cipher_openpgp_to_gcry (kdf_params->keywrap_7836.keywrap_cipher_algo),
+                            cipher_params_to_sbox (&kdf_params->keywrap_7836.keywrap_cipher_params),
+                            map_mac_openpgp_to_gcry (kdf_params->keywrap_7836.keywrap_mac_algo),
+                            mac_params_to_sbox (&kdf_params->keywrap_7836.keywrap_mac_params),
                             data_buf + 1, data_len - 1, ukm, kek);
       break;
     default:


### PR DESCRIPTION
## Summary
- update `gost_kdf_params_t` layout
- rename GOST cipher mapping function and fix prototypes
- adapt all callers to new names and struct layout
- adjust default parameter table initialization

## Testing
- `make gost.o` *(fails: fatal error: config.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c9ccb6788832eb21d76a0bf9f4648