### PR TITLE
Fix includes for gost-kdf build

### DIFF
--- a/g10/gost-kdf.c
+++ b/g10/gost-kdf.c
@@ -1,6 +1,10 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gcrypt.h>
+#include <gpg-error.h>
+
+#include "../common/openpgpdefs.h"
 
 #include "gost-kdf.h"
 #include "gost-map.h"


### PR DESCRIPTION
## Summary
- include gcrypt and gpg-error in gost-kdf
- add openpgpdefs.h for required types

## Testing
- `./autogen.sh` *(fails: `autoconf` not installed)*
- `make` *(fails: No makefile)*

------
https://chatgpt.com/codex/tasks/task_e_684d317c7cf8832e843468dda9ca34e4