### PR TITLE
Enable GOST2012 keys for keyboxd

### DIFF
--- a/kbx/keybox-openpgp.c
+++ b/kbx/keybox-openpgp.c
@@ -213,6 +213,8 @@ keygrip_from_keyparm (int algo, struct keyparm_s *kp, unsigned char *grip)
     case PUBKEY_ALGO_EDDSA:
     case PUBKEY_ALGO_ECDSA:
     case PUBKEY_ALGO_ECDH:
+    case PUBKEY_ALGO_GOST12_256:
+    case PUBKEY_ALGO_GOST12_512:
       {
         char *curve = openpgp_oidbuf_to_str (kp[0].mpi, kp[0].len);
         if (!curve)
@@ -349,6 +351,8 @@ parse_key (const unsigned char *data, size_t datalen,
       break;
     case PUBKEY_ALGO_ECDSA:
     case PUBKEY_ALGO_EDDSA:
+    case PUBKEY_ALGO_GOST12_256:
+    case PUBKEY_ALGO_GOST12_512:
       npkey = 2;
       is_ecc = 1;
       break;


### PR DESCRIPTION
## Summary
- support GOST R 34.10‑2012 algorithms in keybox parsing

## Testing
- `make -C kbx keybox-openpgp.o` *(fails: `fatal error: config.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684d549b7bf4832eb7c7cdd4246c9a8d