### PR TITLE
Add option to disable keyboxd

### DIFF
--- a/common/comopt.c
+++ b/common/comopt.c
@@ -44,6 +44,7 @@ enum opt_values
 
     oLogFile = 500,
     oUseKeyboxd,
+    oNoKeyboxd,
     oKeyboxdProgram,
     oNoAutostart,
 
@@ -53,6 +54,7 @@ enum opt_values
 static gpgrt_opt_t opts[] = {
   ARGPARSE_s_s (oLogFile,        "log-file", "@"),
   ARGPARSE_s_n (oUseKeyboxd,     "use-keyboxd", "@"),
+  ARGPARSE_s_n (oNoKeyboxd,      "no-keyboxd", "@"),
   ARGPARSE_s_n (oNoAutostart,    "no-autostart", "@"),
   ARGPARSE_s_s (oKeyboxdProgram, "keyboxd-program", "@"),
 
@@ -104,6 +106,10 @@ parse_comopt (int module_id, int verbose)
 
         case oUseKeyboxd:
           comopt.use_keyboxd = 1;
+          break;
+
+        case oNoKeyboxd:
+          comopt.use_keyboxd = 0;
           break;
 
         case oNoAutostart:

--- a/g10/gpg.c
+++ b/g10/gpg.c
@@ -383,6 +383,7 @@ enum cmd_and_opt_values
     oNoUseAgent,
     oGpgAgentInfo,
     oUseKeyboxd,
+    oNoKeyboxd,
     oMergeOnly,
     oTryAllSecrets,
     oTrustedKey,
@@ -948,6 +949,7 @@ static gpgrt_opt_t opts[] = {
   ARGPARSE_s_s (oChUid,      "chuid",      "@"),
   ARGPARSE_s_n (oNoAutostart, "no-autostart", "@"),
   ARGPARSE_s_n (oUseKeyboxd,    "use-keyboxd", "@"),
+  ARGPARSE_s_n (oNoKeyboxd,     "no-keyboxd", "@"),
   ARGPARSE_s_n (oForbidGenKey,  "forbid-gen-key", "@"),
   ARGPARSE_s_n (oRequireCompliance, "require-compliance", "@"),
   ARGPARSE_s_s (oCompatibilityFlags, "compatibility-flags", "@"),
@@ -2864,6 +2866,10 @@ main (int argc, char **argv)
 
           case oUseKeyboxd:
             opt.use_keyboxd = 1;
+            break;
+
+          case oNoKeyboxd:
+            opt.use_keyboxd = 0;
             break;
 
           case oReaderPort:

--- a/sm/gpgsm.c
+++ b/sm/gpgsm.c
@@ -213,6 +213,7 @@ enum cmd_and_opt_values {
   oAttribute,
   oChUid,
   oUseKeyboxd,
+  oNoKeyboxd,
   oKeyboxdProgram,
   oRequireCompliance,
   oCompatibilityFlags,
@@ -371,6 +372,7 @@ static gpgrt_opt_t opts[] = {
   ARGPARSE_s_s (oKeyServer_deprecated, "ldapserver", "@"),
   ARGPARSE_s_s (oKeyServer, "keyserver", "@"),
   ARGPARSE_s_n (oUseKeyboxd,    "use-keyboxd", "@"),
+  ARGPARSE_s_n (oNoKeyboxd,     "no-keyboxd", "@"),
 
 
   ARGPARSE_header ("ImportExport",
@@ -1294,6 +1296,7 @@ main ( int argc, char **argv)
 
         case oKeyring: append_to_strlist (&nrings, pargs.r.ret_str); break;
         case oUseKeyboxd: opt.use_keyboxd = 1; break;
+        case oNoKeyboxd: opt.use_keyboxd = 0; break;
 
         case oDebug:
           if (parse_debug_flag (pargs.r.ret_str, &debug_value, debug_flags))


### PR DESCRIPTION
## Summary
- add `--no-keyboxd` option and config parser support

## Testing
- `./autogen.sh --silent` *(fails: `autoconf` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d60ea9c7c832ebf3c68b641de27f2