### PR TITLE
Change map_key_oid_to_pk_openpgp return type

### DIFF
--- a/common/openpgp-oid.c
+++ b/common/openpgp-oid.c
@@ -497,11 +497,11 @@ map_key_oid_to_md_openpgp (gcry_mpi_t a)
 
 /* Map a curve OID to the corresponding OpenPGP public key algorithm.
  * Returns 0 if the OID does not identify a GOST algorithm.  */
-pubkey_algo_t
+int
 map_key_oid_to_pk_openpgp (gcry_mpi_t a)
 {
   char *oidstr = openpgp_oid_to_str (a);
-  pubkey_algo_t result = 0;
+  int result = 0;
 
   if (oidstr &&
       (0 == strncmp (oidstr, "1.2.643.2.2.35.", 15) ||

--- a/common/util.h
+++ b/common/util.h
@@ -237,7 +237,7 @@ int openpgp_oid_is_ed448 (gcry_mpi_t a);
 int openpgp_oidstr_is_gost (const char *oidstr);
 int openpgp_oid_is_gost (gcry_mpi_t a);
 int map_key_oid_to_md_openpgp (gcry_mpi_t a);
-pubkey_algo_t map_key_oid_to_pk_openpgp (gcry_mpi_t a);
+int map_key_oid_to_pk_openpgp (gcry_mpi_t a);
 enum gcry_kem_algos openpgp_oid_to_kem_algo (const char *oidname);
 const char *openpgp_curve_to_oid (const char *name,
                                   unsigned int *r_nbits, int *r_algo,

--- a/g10/parse-packet.c
+++ b/g10/parse-packet.c
@@ -2789,12 +2789,14 @@ parse_key (IOBUF inp, int pkttype, unsigned long pktlen,
 
   if (!err && algorithm == PUBKEY_ALGO_ECDH)
     {
-      pubkey_algo_t galgo = map_key_oid_to_pk_openpgp (pk->pkey[0]);
-      if (galgo)
-        {
-          algorithm = galgo;
-          pk->pubkey_algo = galgo;
-        }
+      {
+        int galgo = map_key_oid_to_pk_openpgp (pk->pkey[0]);
+        if (galgo)
+          {
+            algorithm = galgo;
+            pk->pubkey_algo = galgo;
+          }
+      }
     }
   if (list_mode)
     keyid_from_pk (pk, keyid);


### PR DESCRIPTION
## Summary
- change `map_key_oid_to_pk_openpgp` to return `int`
- adjust declaration in util.h
- update caller in `parse-packet.c`

## Testing
- `./configure --enable-maintainer-mode` *(fails: Required libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebd021df0832e99afeec502b72d88