### PR TITLE
Add GOST digest handling

### DIFF
--- a/g10/cpr.c
+++ b/g10/cpr.c
@@ -421,7 +421,7 @@ write_status_begin_signing (gcry_md_hd_t md)
       int i, ga;
 
       buflen = 0;
-      for (i=1; i <= 110; i++)
+      for (i=1; i <= 255; i++)
         {
           ga = map_md_openpgp_to_gcry (i);
           if (ga && gcry_md_is_enabled (md, ga) && buflen+10 < DIM(buf))

--- a/g10/encrypt.c
+++ b/g10/encrypt.c
@@ -740,8 +740,8 @@ setup_symkey (STRING2KEY **symkey_s2k, DEK **symkey_dek)
   if (!gnupg_digest_is_allowed (opt.compliance, 1, s2kdigest))
     {
       log_error (_("digest algorithm '%s' may not be used in %s mode\n"),
-		 gcry_md_algo_name (s2kdigest),
-		 gnupg_compliance_option_string (opt.compliance));
+                 openpgp_md_algo_name (s2kdigest),
+                 gnupg_compliance_option_string (opt.compliance));
       return gpg_error (GPG_ERR_DIGEST_ALGO);
     }
 

--- a/g10/gpg.c
+++ b/g10/gpg.c
@@ -4256,13 +4256,13 @@ main (int argc, char **argv)
 	else if(opt.def_digest_algo
 		&& !algo_available(PREFTYPE_HASH,opt.def_digest_algo,NULL))
 	  {
-	    badalg = gcry_md_algo_name (opt.def_digest_algo);
+            badalg = openpgp_md_algo_name (opt.def_digest_algo);
 	    badtype = PREFTYPE_HASH;
 	  }
 	else if(opt.cert_digest_algo
 		&& !algo_available(PREFTYPE_HASH,opt.cert_digest_algo,NULL))
 	  {
-	    badalg = gcry_md_algo_name (opt.cert_digest_algo);
+            badalg = openpgp_md_algo_name (opt.cert_digest_algo);
 	    badtype = PREFTYPE_HASH;
 	  }
 	else if(opt.compress_algo!=-1
@@ -4332,8 +4332,8 @@ main (int argc, char **argv)
 				      || cmd == aClearsign,
 				      opt.def_digest_algo))
       log_error (_("digest algorithm '%s' may not be used in %s mode\n"),
-		 gcry_md_algo_name (opt.def_digest_algo),
-		 gnupg_compliance_option_string (opt.compliance));
+                 openpgp_md_algo_name (opt.def_digest_algo),
+                 gnupg_compliance_option_string (opt.compliance));
 
     /* Fail hard.  */
     if (log_get_errorcount (0))
@@ -5711,7 +5711,8 @@ print_hex (gcry_md_hd_t md, int algo, const char *fname)
   if (algo==DIGEST_ALGO_RMD160)
     indent += es_printf("RMD160 = ");
   else if (algo>0)
-    indent += es_printf("%6s = ", gcry_md_algo_name (algo));
+    indent += es_printf("%6s = ",
+                        gcry_md_algo_name (map_md_openpgp_to_gcry (algo)));
   else
     algo = abs(algo);
 

--- a/g10/import.c
+++ b/g10/import.c
@@ -1364,9 +1364,9 @@ check_prefs (ctrl_t ctrl, kbnode_t keyblock)
 		      problem=1;
 		    }
 		}
-	      else if(prefs->type==PREFTYPE_AEAD)
-		{
-		  if (openpgp_aead_test_algo (prefs->value))
+                      const char *algo =
+                        (openpgp_md_test_algo (prefs->value)
+                         : openpgp_md_algo_name (prefs->value));
 		    {
                       /* FIXME: The test below is wrong.  We should
                        * check if ...algo_name yields a "?" and

--- a/g10/keylist.c
+++ b/g10/keylist.c
@@ -414,10 +414,13 @@ show_preferences (PKT_user_id *uid, int indent, int mode, int verbose)
 	    tty_fprintf (fp, ", ");
 	  tty_fprintf (fp, "%s", openpgp_cipher_algo_name (CIPHER_ALGO_3DES));
 	}
-      tty_fprintf (fp, "\n%*s %s", indent, "", _("AEAD: "));
-      for (i = any = 0; prefs[i].type; i++)
+              if (!openpgp_md_test_algo (prefs[i].value)
+                  && prefs[i].value < 100)
+                tty_fprintf (fp, "%s",
+                              openpgp_md_algo_name (prefs[i].value));
 	{
-	  if (prefs[i].type == PREFTYPE_AEAD)
+          tty_fprintf (fp, "%s",
+                       openpgp_md_algo_name (DIGEST_ALGO_SHA1));
 	    {
 	      if (any)
 		tty_fprintf (fp, ", ");

--- a/g10/mainproc.c
+++ b/g10/mainproc.c
@@ -2563,7 +2563,7 @@ check_sig_and_print (CTX c, kbnode_t node)
           log_info (_("%s signature, digest algorithm %s%s%s\n"),
                     sig->sig_class==0x00?_("binary"):
                     sig->sig_class==0x01?_("textmode"):_("unknown"),
-                    gcry_md_algo_name (sig->digest_algo),
+                    openpgp_md_algo_name (sig->digest_algo),
                     *pkstrbuf?_(", key algorithm "):"", pkstrbuf);
         }
 

--- a/g10/misc.c
+++ b/g10/misc.c
@@ -898,6 +898,26 @@ map_md_openpgp_to_gcry (digest_algo_t algo)
 #else
     case DIGEST_ALGO_SHA512: return 0;
 #endif
+#ifdef GPG_USE_GOST
+    case DIGEST_ALGO_GOSTR3411_12_256:
+#ifdef GCRY_MD_STRIBOG256
+      return GCRY_MD_STRIBOG256;
+#else
+      return 0;
+#endif
+    case DIGEST_ALGO_GOSTR3411_12_512:
+#ifdef GCRY_MD_STRIBOG512
+      return GCRY_MD_STRIBOG512;
+#else
+      return 0;
+#endif
+    case DIGEST_ALGO_GOSTR3411_94:
+#ifdef GCRY_MD_GOSTR3411_CP
+      return GCRY_MD_GOSTR3411_CP;
+#else
+      return 0;
+#endif
+#endif /* GPG_USE_GOST */
     default: return 0;
     }
 }
@@ -933,6 +953,11 @@ openpgp_md_algo_name (int algo)
     case DIGEST_ALGO_SHA384: return "SHA384";
     case DIGEST_ALGO_SHA512: return "SHA512";
     case DIGEST_ALGO_SHA224: return "SHA224";
+#ifdef GPG_USE_GOST
+    case DIGEST_ALGO_GOSTR3411_12_256: return "GOST3411-12-256";
+    case DIGEST_ALGO_GOSTR3411_12_512: return "GOST3411-12-512";
+    case DIGEST_ALGO_GOSTR3411_94:     return "GOST3411-94";
+#endif
     }
   return "?";
 }

--- a/g10/seskey.c
+++ b/g10/seskey.c
@@ -334,7 +334,7 @@ encode_md_value (PKT_public_key *pk, gcry_md_hd_t md, int hash_algo)
                        "(hash is %s)\n"),
                      openpgp_pk_algo_name (pk->pubkey_algo),
                      keystr_from_pk (pk), qbits,
-                     gcry_md_algo_name (hash_algo));
+                     gcry_md_algo_name (map_md_openpgp_to_gcry (hash_algo)));
 	  return NULL;
 	}
 

--- a/g10/sig-check.c
+++ b/g10/sig-check.c
@@ -171,7 +171,7 @@ check_signature (ctrl_t ctrl,
     {
       /* Compliance failure.  */
       log_info (_("digest algorithm '%s' may not be used in %s mode\n"),
-                gcry_md_algo_name (sig->digest_algo),
+                openpgp_md_algo_name (sig->digest_algo),
                 gnupg_compliance_option_string (opt.compliance));
       rc = gpg_error (GPG_ERR_DIGEST_ALGO);
     }
@@ -793,7 +793,7 @@ check_revocation_keys (ctrl_t ctrl, PKT_public_key *pk, PKT_signature *sig)
 	    {
               gcry_md_hd_t md;
 
-              if (gcry_md_open (&md, sig->digest_algo, 0))
+              if (gcry_md_open (&md, map_md_openpgp_to_gcry (sig->digest_algo), 0))
                 BUG ();
               hash_public_key(md,pk);
 	      /* Note: check_signature only checks that the signature
@@ -836,7 +836,7 @@ check_backsig (PKT_public_key *main_pk,PKT_public_key *sub_pk,
   if(!opt.no_sig_cache && backsig->flags.checked)
     return backsig->flags.valid? 0 : gpg_error (GPG_ERR_BAD_SIGNATURE);
 
-  rc = gcry_md_open (&md, backsig->digest_algo,0);
+  rc = gcry_md_open (&md, map_md_openpgp_to_gcry (backsig->digest_algo), 0);
   if (!rc)
     {
       hash_public_key(md,main_pk);
@@ -1019,7 +1019,7 @@ check_signature_over_key_or_uid (ctrl_t ctrl, PKT_public_key *signer,
 
   /* We checked above that we supported this algo, so an error here is
    * a bug.  */
-  if (gcry_md_open (&md, sig->digest_algo, 0))
+  if (gcry_md_open (&md, map_md_openpgp_to_gcry (sig->digest_algo), 0))
     BUG ();
 
   /* Hash the relevant data.  */


### PR DESCRIPTION
## Summary
- map new GOST digest algos to Libgcrypt and name strings
- hook GOST digest mapping into signing and verification
- show GOST digest names in user messages
- support GOST digests in BEGIN_SIGNING status

## Testing
- `make -j2 check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684ec7827a40832e846fdc9015d08328