### PR TITLE
Fix GOST algorithm parsing

### DIFF
--- a/g10/keyid.c
+++ b/g10/keyid.c
@@ -125,6 +125,9 @@ pubkey_string (PKT_public_key *pk, char *buffer, size_t bufsize)
     case PUBKEY_ALGO_ECDH:
     case PUBKEY_ALGO_ECDSA:
     case PUBKEY_ALGO_EDDSA:     prefix = "";    break;
+    case PUBKEY_ALGO_GOST12_256:
+    case PUBKEY_ALGO_GOST12_512:
+    case PUBKEY_ALGO_GOST2001:  prefix = "";    break;
     case PUBKEY_ALGO_KYBER:     prefix = "ky"; dual = 1;  break;
     case PUBKEY_ALGO_DIL3_25519:  prefix = "dil3";        break;
     case PUBKEY_ALGO_DIL5_448:    prefix = "dil5";        break;

--- a/g10/misc.c
+++ b/g10/misc.c
@@ -70,6 +70,7 @@
 #include "../common/i18n.h"
 #include "../common/zb32.h"
 
+#define GPG_USE_GOST 1
 
 /* FIXME: Libgcrypt 1.9 will support EAX.  Until we name this a
  * requirement we hardwire the enum used for EAX.  */

--- a/g10/parse-packet.c
+++ b/g10/parse-packet.c
@@ -2509,7 +2509,10 @@ parse_signature (IOBUF inp, int pkttype, unsigned long pktlen,
 	{
 	  n = pktlen;
           if (sig->pubkey_algo == PUBKEY_ALGO_ECDSA
-              || sig->pubkey_algo == PUBKEY_ALGO_EDDSA)
+              || sig->pubkey_algo == PUBKEY_ALGO_EDDSA
+              || sig->pubkey_algo == PUBKEY_ALGO_GOST12_256
+              || sig->pubkey_algo == PUBKEY_ALGO_GOST12_512
+              || sig->pubkey_algo == PUBKEY_ALGO_GOST2001)
             sig->data[i] = sos_read (inp, &n, 0);
           else
             sig->data[i] = mpi_read (inp, &n, 0);
@@ -2741,7 +2744,11 @@ parse_key (IOBUF inp, int pkttype, unsigned long pktlen,
           if (    (algorithm == PUBKEY_ALGO_ECDSA && (i == 0))
                || (algorithm == PUBKEY_ALGO_EDDSA && (i == 0))
                || (algorithm == PUBKEY_ALGO_ECDH  && (i == 0 || i == 2))
-               || (algorithm == PUBKEY_ALGO_KYBER && (i == 0)))
+               || (algorithm == PUBKEY_ALGO_KYBER && (i == 0))
+               || ((algorithm == PUBKEY_ALGO_GOST12_256
+                    || algorithm == PUBKEY_ALGO_GOST12_512
+                    || algorithm == PUBKEY_ALGO_GOST2001)
+                   && (i == 0)))
             {
               /* Read the OID (i==0) or the KDF params (i==2).  */
 	      err = read_sized_octet_string (inp, &pktlen, pk->pkey+i);
@@ -2758,7 +2765,10 @@ parse_key (IOBUF inp, int pkttype, unsigned long pktlen,
               if (algorithm == PUBKEY_ALGO_ECDSA
                   || algorithm == PUBKEY_ALGO_EDDSA
                   || algorithm == PUBKEY_ALGO_ECDH
-                  || algorithm == PUBKEY_ALGO_KYBER)
+                  || algorithm == PUBKEY_ALGO_KYBER
+                  || algorithm == PUBKEY_ALGO_GOST12_256
+                  || algorithm == PUBKEY_ALGO_GOST12_512
+                  || algorithm == PUBKEY_ALGO_GOST2001)
                 pk->pkey[i] = sos_read (inp, &n, 0);
               else
                 pk->pkey[i] = mpi_read (inp, &n, 0);
@@ -2775,7 +2785,10 @@ parse_key (IOBUF inp, int pkttype, unsigned long pktlen,
               if ((algorithm == PUBKEY_ALGO_ECDSA
                    || algorithm == PUBKEY_ALGO_EDDSA
                    || algorithm == PUBKEY_ALGO_ECDH
-                   || algorithm == PUBKEY_ALGO_KYBER) && i==0)
+                   || algorithm == PUBKEY_ALGO_KYBER
+                   || algorithm == PUBKEY_ALGO_GOST12_256
+                   || algorithm == PUBKEY_ALGO_GOST12_512
+                   || algorithm == PUBKEY_ALGO_GOST2001) && i==0)
                 {
                   char *curve = openpgp_oid_to_str (pk->pkey[0]);
                   const char *name = openpgp_oid_to_curve (curve, 0);
@@ -3143,7 +3156,10 @@ parse_key (IOBUF inp, int pkttype, unsigned long pktlen,
                   if (algorithm == PUBKEY_ALGO_ECDSA
                       || algorithm == PUBKEY_ALGO_EDDSA
                       || algorithm == PUBKEY_ALGO_ECDH
-                      || algorithm == PUBKEY_ALGO_KYBER)
+                      || algorithm == PUBKEY_ALGO_KYBER
+                      || algorithm == PUBKEY_ALGO_GOST12_256
+                      || algorithm == PUBKEY_ALGO_GOST12_512
+                      || algorithm == PUBKEY_ALGO_GOST2001)
                     pk->pkey[i] = sos_read (inp, &n, 0);
                   else
                     pk->pkey[i] = mpi_read (inp, &n, 0);


### PR DESCRIPTION
## Summary
- support GOST algorithms when listing public keys
- parse GOST keys and signatures properly
- enable GOST feature flags so hash names resolve correctly

## Testing
- `make -j2 check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684ee1c80864832e8d428f94971849cb