### PR TITLE
Fix freeing of GOST default params buffer

### DIFF
--- a/g10/gost.c
+++ b/g10/gost.c
@@ -116,7 +116,7 @@ gpg_error_t pk_gost_default_params(const char *oidstr,
         return err;
 
     buf[0] = len + 1;
-    *r_params = gcry_mpi_set_opaque(*r_params, buf, (len + 2) * 8);
+    *r_params = gcry_mpi_set_opaque_copy (*r_params, buf, (len + 2) * 8);
     return *r_params ? GPG_ERR_NO_ERROR : gpg_error_from_syserror();
 }
 


### PR DESCRIPTION
## Summary
- avoid invalid free in `pk_gost_default_params`

## Testing
- `make -j2` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7723ec0832eb598d5463bd7649e