### PR TITLE
Fix mapping of GOST curves to algorithms

### DIFF
--- a/g10/keygen.c
+++ b/g10/keygen.c
@@ -3864,6 +3864,11 @@ ask_user_id (int mode, int full, KBNODE keyblock)
 	    }
 	    xfree(answer);
 	}
+  int curve_algo = 0;
+
+  if (curve && openpgp_is_curve_supported (curve, &curve_algo, NULL)
+      && curve_algo && (algo == PUBKEY_ALGO_ECDH || algo == PUBKEY_ALGO_ECDSA))
+    algo = curve_algo;
 	xfree(answer);
 	if (!amail && !acomment)
 	    break;

--- a/g10/sign.c
+++ b/g10/sign.c
@@ -711,8 +711,11 @@ hash_for (PKT_public_key *pk)
 
       return match_dsa_hash (pk, qbytes);
     }
-  else if (pk->pubkey_algo == PUBKEY_ALGO_ECDH &&
-           openpgp_oid_is_gost (pk->pkey[0]))
+  else if ((pk->pubkey_algo == PUBKEY_ALGO_ECDH &&
+            openpgp_oid_is_gost (pk->pkey[0])) ||
+           pk->pubkey_algo == PUBKEY_ALGO_GOST12_256 ||
+           pk->pubkey_algo == PUBKEY_ALGO_GOST12_512 ||
+           pk->pubkey_algo == PUBKEY_ALGO_GOST2001)
     {
       return map_key_oid_to_md_openpgp (pk->pkey[0]);
     }


### PR DESCRIPTION
## Summary
- ensure curve-specific algorithms are applied in key generation
- support GOST pubkey algorithms when selecting digests

## Testing
- `./autogen.sh` *(fails: `autoconf` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684eebd7e804832e96b110f8eb02f636