### PR TITLE
Fix GOST digest mapping and listing

### DIFF
--- a/g10/gpg.c
+++ b/g10/gpg.c
@@ -1301,7 +1301,7 @@ build_list (const char *text, char letter,
   len = 0;
   init_membuf (&mb, 512);
 
-  limit = (letter == 'A')? 4 : 110;
+  limit = (letter == 'A')? 4 : 255;
   for (i=0; i <= limit; i++ )
     {
       if (!chkf (i) && (s = mapf (i)))
@@ -1830,7 +1830,7 @@ print_algo_numbers(int (*checker)(int))
 {
   int i,first=1;
 
-  for(i=0;i<=110;i++)
+  for(i=0;i<=255;i++)
     {
       if(!checker(i))
 	{
@@ -1849,7 +1849,7 @@ print_algo_names(int (*checker)(int),const char *(*mapper)(int))
 {
   int i,first=1;
 
-  for(i=0;i<=110;i++)
+  for(i=0;i<=255;i++)
     {
       if(!checker(i))
 	{

--- a/g10/sign.c
+++ b/g10/sign.c
@@ -993,8 +993,10 @@ write_signature_packets (ctrl_t ctrl,
       hash_sigversion_to_magic (md, sig, extrahash);
       gcry_md_final (md);
 
-      if (!err)
-        err = do_sign (ctrl, pk, sig, md, hash_for (pk), cache_nonce, 0);
+        if (!err)
+          err = do_sign (ctrl, pk, sig, md,
+                         map_md_openpgp_to_gcry (hash_for (pk)),
+                         cache_nonce, 0);
       gcry_md_close (md);
       if (!err)
         {


### PR DESCRIPTION
## Summary
- ensure config listing enumerates all digest algorithms
- use correct libgcrypt digest when signing with GOST keys

## Testing
- `gpg --with-colons --list-config | grep digest` *(fails: digest list still from system gpg)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9c0bcd8832e93e474f59c63815a