### PR TITLE
Support mapping for Streebog digest

### DIFF
--- a/g10/main.h
+++ b/g10/main.h
@@ -141,6 +141,7 @@ int openpgp_pk_algo_usage ( int algo );
 const char *openpgp_pk_algo_name (pubkey_algo_t algo);
 
 enum gcry_md_algos map_md_openpgp_to_gcry (digest_algo_t algo);
+digest_algo_t map_md_gcry_to_openpgp (enum gcry_md_algos algo);
 int openpgp_md_test_algo (digest_algo_t algo);
 const char *openpgp_md_algo_name (int algo);
 

--- a/g10/misc.c
+++ b/g10/misc.c
@@ -923,6 +923,33 @@ map_md_openpgp_to_gcry (digest_algo_t algo)
     }
 }
 
+/* Map a Libgcrypt digest algorithm to the corresponding OpenPGP
+   identifier.  Returns 0 for unknown algorithms.  */
+digest_algo_t
+map_md_gcry_to_openpgp (enum gcry_md_algos algo)
+{
+  switch (algo)
+    {
+    case GCRY_MD_MD5:       return DIGEST_ALGO_MD5;
+    case GCRY_MD_SHA1:      return DIGEST_ALGO_SHA1;
+    case GCRY_MD_RMD160:    return DIGEST_ALGO_RMD160;
+    case GCRY_MD_SHA256:    return DIGEST_ALGO_SHA256;
+    case GCRY_MD_SHA384:    return DIGEST_ALGO_SHA384;
+    case GCRY_MD_SHA512:    return DIGEST_ALGO_SHA512;
+    case GCRY_MD_SHA224:    return DIGEST_ALGO_SHA224;
+#ifdef GCRY_MD_GOSTR3411_CP
+    case GCRY_MD_GOSTR3411_CP: return DIGEST_ALGO_GOSTR3411_94;
+#endif
+#ifdef GCRY_MD_STRIBOG256
+    case GCRY_MD_STRIBOG256: return DIGEST_ALGO_GOSTR3411_12_256;
+#endif
+#ifdef GCRY_MD_STRIBOG512
+    case GCRY_MD_STRIBOG512: return DIGEST_ALGO_GOSTR3411_12_512;
+#endif
+    default: return 0;
+    }
+}
+
 
 /* Return 0 if ALGO is suitable and implemented OpenPGP hash
    algorithm.  */

--- a/g10/sign.c
+++ b/g10/sign.c
@@ -429,7 +429,7 @@ do_sign (ctrl_t ctrl, PKT_public_key *pksk, PKT_signature *sig,
   print_pubkey_algo_note (pksk->pubkey_algo);
 
   if (!mdalgo)
-    mdalgo = gcry_md_get_algo (md);
+    mdalgo = map_md_gcry_to_openpgp (gcry_md_get_algo (md));
 
   if ((signhints & SIGNHINT_KEYSIG) && !(signhints & SIGNHINT_SELFSIG)
       && mdalgo == GCRY_MD_SHA1
@@ -478,7 +478,7 @@ do_sign (ctrl_t ctrl, PKT_public_key *pksk, PKT_signature *sig,
     }
 
   print_digest_algo_note (mdalgo);
-  dp = gcry_md_read  (md, mdalgo);
+  dp = gcry_md_read (md, map_md_openpgp_to_gcry (mdalgo));
   sig->digest_algo = mdalgo;
   sig->digest_start[0] = dp[0];
   sig->digest_start[1] = dp[1];
@@ -498,7 +498,9 @@ do_sign (ctrl_t ctrl, PKT_public_key *pksk, PKT_signature *sig,
       /* FIXME: Eventually support dual keys.  */
       err = agent_pksign (NULL/*ctrl*/, cache_nonce, hexgrip, desc,
                           pksk->keyid, pksk->main_keyid, pksk->pubkey_algo,
-                          dp, gcry_md_get_algo_dlen (mdalgo), mdalgo,
+                          dp,
+                          gcry_md_get_algo_dlen (map_md_openpgp_to_gcry (mdalgo)),
+                          map_md_openpgp_to_gcry (mdalgo),
                           &s_sigval);
       xfree (desc);
 


### PR DESCRIPTION
## Summary
- map libgcrypt STRIBOG algorithms to OpenPGP ids
- expose new helper in headers
- use OpenPGP id in signing code and convert when calling libgcrypt

## Testing
- `gcc /tmp/test_gcrypt.c -o /tmp/test_gcrypt -lgcrypt -lgpg-error && /tmp/test_gcrypt`

------
https://chatgpt.com/codex/tasks/task_e_684f03930978832e9cb060710b68e035