### PR TITLE
Fix md algorithm mapping for GOST digests

### DIFF
--- a/g10/decrypt-data.c
+++ b/g10/decrypt-data.c
@@ -411,8 +411,9 @@ decrypt_data (ctrl_t ctrl, void *procctx, PKT_encrypted *ed, DEK *dek,
 
       if ( ed->mdc_method )
         {
-          if (gcry_md_open (&dfx->mdc_hash, ed->mdc_method, 0 ))
-            BUG ();
+          if (gcry_md_open (&dfx->mdc_hash,
+                            map_md_openpgp_to_gcry (ed->mdc_method), 0 ))
+            BUG (); 
           if ( DBG_HASHING )
             gcry_md_debug (dfx->mdc_hash, "checkmdc");
         }
@@ -555,7 +556,8 @@ decrypt_data (ctrl_t ctrl, void *procctx, PKT_encrypted *ed, DEK *dek,
          packet parser.  Fortunatley the OpenPGP spec requires a
          strict format for the MDC packet so that we know that 22
          bytes are appended.  */
-      int datalen = gcry_md_get_algo_dlen (ed->mdc_method);
+      int datalen = gcry_md_get_algo_dlen (map_md_openpgp_to_gcry
+                                            (ed->mdc_method));
 
       log_assert (dfx->cipher_hd);
       log_assert (dfx->mdc_hash);

--- a/g10/gpg.c
+++ b/g10/gpg.c
@@ -5718,8 +5718,8 @@ print_hex (gcry_md_hd_t md, int algo, const char *fname)
 
   count = indent;
 
-  p = gcry_md_read (md, algo);
-  n = gcry_md_get_algo_dlen (algo);
+  p = gcry_md_read (md, map_md_openpgp_to_gcry (algo));
+  n = gcry_md_get_algo_dlen (map_md_openpgp_to_gcry (algo));
 
   count += es_printf ("%02X",*p++);
 
@@ -5792,8 +5792,8 @@ print_hashline( gcry_md_hd_t md, int algo, const char *fname )
     }
   es_putc (':', es_stdout);
   es_printf ("%d:", algo);
-  p = gcry_md_read (md, algo);
-  n = gcry_md_get_algo_dlen (algo);
+  p = gcry_md_read (md, map_md_openpgp_to_gcry (algo));
+  n = gcry_md_get_algo_dlen (map_md_openpgp_to_gcry (algo));
   for(i=0; i < n ; i++, p++ )
     es_printf ("%02X", *p);
   es_fputs (":\n", es_stdout);

--- a/g10/pkclist.c
+++ b/g10/pkclist.c
@@ -1438,7 +1438,7 @@ algo_available( preftype_t preftype, int algo, const struct pref_hint *hint)
     {
       if (hint && hint->digest_length)
 	{
-          unsigned int n = gcry_md_get_algo_dlen (algo);
+          unsigned int n = gcry_md_get_algo_dlen (map_md_openpgp_to_gcry (algo));
 
           if (hint->exact)
             {

--- a/g10/sig-check.c
+++ b/g10/sig-check.c
@@ -538,7 +538,7 @@ check_signature_end_simple (PKT_public_key *pk, PKT_signature *sig,
 
   /* Make sure the digest algo is enabled (in case of a detached
    * signature).  */
-  gcry_md_enable (digest, sig->digest_algo);
+  gcry_md_enable (digest, map_md_openpgp_to_gcry (sig->digest_algo));
 
   /* Complete the digest. */
   if (sig->version >= 4)

--- a/g10/sign.c
+++ b/g10/sign.c
@@ -708,15 +708,17 @@ hash_for (PKT_public_key *pk)
 
 	  if (qbytes != 20 || opt.flags.dsa2)
 	    {
-	      for (prefs=opt.personal_digest_prefs; prefs->type; prefs++)
-		if (gcry_md_get_algo_dlen (prefs->value) >= qbytes)
-		  return prefs->value;
+              for (prefs=opt.personal_digest_prefs; prefs->type; prefs++)
+                if (gcry_md_get_algo_dlen (map_md_openpgp_to_gcry (prefs->value))
+                    >= qbytes)
+                  return prefs->value;
 	    }
 	  else
 	    {
-	      for (prefs=opt.personal_digest_prefs; prefs->type; prefs++)
-		if (gcry_md_get_algo_dlen (prefs->value) == qbytes)
-		  return prefs->value;
+              for (prefs=opt.personal_digest_prefs; prefs->type; prefs++)
+                if (gcry_md_get_algo_dlen (map_md_openpgp_to_gcry (prefs->value))
+                    == qbytes)
+                  return prefs->value;
 	    }
 	}
 


### PR DESCRIPTION
## Summary
- map OpenPGP digest IDs to libgcrypt IDs before calling libgcrypt
- update signature creation and verification to use mapped digest IDs
- ensure digest length checks use libgcrypt algorithms

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684f08e6dddc832e9e682158a5c7636e