### PR TITLE
Fix missing curve OID for GOST keys

### DIFF
--- a/g10/keygen.c
+++ b/g10/keygen.c
@@ -1517,12 +1517,12 @@ ecckey_from_sexp (gcry_mpi_t *array, gcry_sexp_t sexp,
 
   array[0] = NULL;
   array[1] = NULL;
-  array[2] = NULL;
-
-  list = gcry_sexp_find_token (sexp, "public-key", 0);
-  if (!list)
-    return gpg_error (GPG_ERR_INV_OBJ);
-  l2 = gcry_sexp_cadr (list);
+    oidstr = curve; /* Assume CURVE is given as an OID.  */
+  if (err && oidstr != curve)
+    {
+      /* Second try: CURVE may already be an OID.  */
+      err = openpgp_oid_from_str (curve, &array[0]);
+    }
   gcry_sexp_release (list);
   list = l2;
   if (!list)


### PR DESCRIPTION
## Summary
- ensure ecckey_from_sexp always stores the curve OID

## Testing
- `make -C tests check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_684f1ea5c9fc832e8f853f15fda86a10