### PR TITLE
Fix GOST curve OID handling

### DIFF
--- a/g10/keygen.c
+++ b/g10/keygen.c
@@ -1515,7 +1515,18 @@ ecckey_from_sexp (gcry_mpi_t *array, gcry_sexp_t sexp,
   const char *oidstr;
   unsigned int nbits;
 
-  array[0] = NULL;
+            {
+              /* Not found in our table - try using the curve string as
+               * an OID literal.  */
+              err = openpgp_oid_from_str (curve, &array[0]);
+              if (err)
+                {
+                  log_error ("ecckey_from_sexp: unknown curve '%s'\n", curve);
+                  err = 0;
+                }
+              else
+                oidstr = curve; /* For default params below.  */
+            }
   array[1] = NULL;
   array[2] = NULL;
 


### PR DESCRIPTION
## Summary
- handle unknown curve names in `ecckey_from_sexp` by trying to parse the curve string as an OID

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `autoreconf --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f370686f4832eb71c28c85a80fee4